### PR TITLE
Be more forgiving.

### DIFF
--- a/app/Payout.hs
+++ b/app/Payout.hs
@@ -90,11 +90,10 @@ payout (Config baker host port from fromName varyingFee databasePath accountData
               frozenBalanceByCycle <- RPC.frozenBalanceByCycle conf hash baker
               lostEndorsementRewards <- Delegation.lostEndorsementRewards conf cycleLength cycle baker
               T.putStrLn $ T.concat ["Lost endorsement rewards due to other-baker downtime for cycle ", T.pack $ P.show cycle, ": ", T.pack $ P.show lostEndorsementRewards]
-              let frozenBalanceThisCycle = P.filter ((==) cycle . RPC.frozenCycle) frozenBalanceByCycle
-                  inactiveBakerThisCycle = (length frozenBalanceThisCycle == CountOf 0)
-                  feeRewards = if inactiveBakerThisCycle then 0 else (RPC.frozenFees (frozenBalanceThisCycle P.!! 0))
+              let thisCycle = filter ((==) cycle . RPC.frozenCycle) frozenBalanceByCycle ! 0
+                  feeRewards = maybe 0 RPC.frozenFees thisCycle
                   extraRewards = feeRewards P.- lostEndorsementRewards
-                  realizedRewards = if inactiveBakerThisCycle then 0 else (feeRewards P.+ RPC.frozenRewards (frozenBalanceThisCycle P.!! 0 ))
+                  realizedRewards = feeRewards P.+ maybe 0 RPC.frozenRewards thisCycle
                   estimatedRewards = cycleEstimatedTotalRewards cyclePayout
                   paidRewards = estimatedRewards P.+ extraRewards
                   realizedDifference = realizedRewards P.- paidRewards


### PR DESCRIPTION
If the baker has some rolls but does not bake or delegate at all
during a cycle, the program crashes during calculation of the actual
rewards. Fix that.

I tested on alphanet with an active baker and verified that the json db is the same with and without this commit. With an inactive baker, realized rewards show zero.