### PR TITLE
Do not spawn a PTY when doing payouts in --no-password mode

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -39,6 +39,7 @@ context = Context <$> getHomeDirectory
 
 run ∷ Options → IO ()
 run (Options configPath command) = do
+  hSetBuffering stdout LineBuffering
   let withConfig ∷ (Config → IO ()) → IO ()
       withConfig func = do
         maybeConf <- loadConfig configPath

--- a/app/Payout.hs
+++ b/app/Payout.hs
@@ -1,6 +1,7 @@
 module Payout where
 
 import           Control.Concurrent
+import           Control.Exception
 import           Control.Monad
 import qualified Data.ByteString.Char8 as B
 import qualified Data.Map              as M
@@ -300,6 +301,9 @@ payout (Config baker host port from fromName varyingFee databasePath accountData
 waitASecond :: IO ()
 waitASecond = threadDelay (P.round (1e6 :: Double))
 
+try' :: IO a ->  IO (Either IOException a)
+try' =  try
+
 foldFirst3 :: a -> [a -> IO (a, (Bool, IO ()))] -> IO (a, (Bool, IO ()))
 foldFirst3 obj [] = return (obj, (False, return ()))
 foldFirst3 obj (act:rest) = do
@@ -315,20 +319,40 @@ foldFirst obj (act:rest) = do
 sign :: T.Text -> T.Text -> Maybe T.Text -> T.Text -> T.Text -> IO T.Text
 sign clientPath clientConfigFile fromPassword account what = do
   let args = ["-c", clientConfigFile, "sign", "bytes", "0x03" <> what, "for", account]
-  T.putStrLn $ T.concat ["Running '", T.intercalate " " (clientPath : args), "' in a pty"]
-  (pty, handle) <- P.spawnWithPty Nothing True (T.unpack clientPath) (fmap T.unpack args) (80, 80)
-  waitASecond
-  P.threadWaitReadPty pty
-  stderr <- P.readPty pty
-  P.threadWaitWritePty pty
-  P.writePty pty (B.pack $ T.unpack $ case fromPassword of Just pass -> T.concat [pass, "\n"]; Nothing -> "")
-  waitASecond
-  code <- P.waitForProcess handle
-  stdout <- P.readPty pty
-  P.closePty pty
-  if code /= ExitSuccess then do
-    T.putStrLn $ T.concat ["Failure: ", T.pack $ P.show (code, stdout, stderr)]
-    exitFailure
-  else do
-    let asText = T.pack $ B.unpack stdout
-    return $ T.drop 13 $ T.take (T.length asText - 2) asText
+  asText <- do
+    case fromPassword of
+      Just pass -> do
+        T.putStrLn $ T.concat ["Running '", T.intercalate " " (clientPath : args), "' in a pty"]
+        (pty, handle) <- P.spawnWithPty Nothing True (T.unpack clientPath) (fmap T.unpack args) (80, 80)
+        waitASecond
+        P.threadWaitReadPty pty
+        stderr <- P.readPty pty
+        P.threadWaitWritePty pty
+        P.writePty pty (B.pack $ T.unpack $ T.concat [pass, "\n"])
+        waitASecond
+        code <- P.waitForProcess handle
+        stdout <- P.readPty pty
+        P.closePty pty
+        if code /= ExitSuccess then do
+          T.putStrLn $ T.concat ["Failure: ", T.pack $ P.show (code, stdout, stderr)]
+          exitFailure
+        else do
+          let asText = T.pack $ B.unpack stdout
+          return asText
+      Nothing -> do
+        T.putStrLn $ T.concat ["Running '", T.intercalate " " (clientPath : args), "' in a subprocess"]
+        result <- try' $ P.createProcess (P.proc (P.show clientPath) (P.map P.show args)){ P.std_out = P.CreatePipe }
+        case result of
+          Left ex -> do
+            T.putStrLn $ T.concat [ "Subprocess returned an exception: ", T.pack $ P.show ex ]
+            exitFailure
+          Right (_, Nothing , _, _) -> do
+            T.putStrLn "Error: subprocess returned nothing"
+            exitFailure
+          Right (_, Just hout, _, _) -> do
+            T.putStrLn "Success"
+            asText <- T.hGetContents hout
+            return asText
+  T.putStrLn "> output of signature"
+  T.putStrLn asText
+  return $ T.drop 13 $ T.take (T.length asText - 2) asText


### PR DESCRIPTION
This allows to run payouts from a Docker container in non-interactive mode

Also enable line buffering for running inside container and collecting logs.