### PR TITLE
Add preserved cycles for alphanet and add payout delay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ Bäckerei is fairly well tested, but be careful! Ensure you trust the Tezos node
 to which you are connecting. In any case, you would be well-advised to pay from 
 an isolated account with the minimal requisite balance.
 
+#### Consants
+
+Different networks such as alphanet may have different constants. You need to specify these constants during initialiation for Backerei to work correctly.
+
+The default values for these constants work on the Tezos mainnet.
+
+* `--cycle-length` defaults to 4096. For alphanet, set to 2048
+* `--snapshot-interval` defaults to 512. For alphanet, set to 256
+* `--preserved-cycles`: defaults to 5. For alphanet, set to 3
+
+#### Delayed payouts
+
+By default, the payouts are paid after `PRESERVED_CYCLES`, which corresponds to when
+the Tezos network unfreezes them. You may choose to pay them earlier or later:
+
+* `--payout-delay 2` will pay the rewards two cycles (six days) later
+* `--payout-delay -1` will pay the rewards one cycle (three days) before you actually
+get access to them
+
 #### Verifying payouts
 
 You can find historical payout logs for Cryptium Labs 

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -22,6 +22,8 @@ data Config = Config {
   configStartingCycle       :: Int,
   configCycleLength         :: Int,
   configSnapshotInterval    :: Int,
+  configPreservedCycles     :: Int,
+  configPayoutDelay         :: Int,
   configTelegram            :: Maybe TelegramConfig,
   configRiemann             :: Maybe RiemannConfig,
   configPostPayoutScript    :: Maybe T.Text

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -51,8 +51,8 @@ run (Options configPath command) = do
     Version -> do
       putDoc versionDoc
       exitSuccess
-    Init addr host port from fromName fee dbPath clientPath clientConfigFile startingCycle cycleLength snapshotInterval -> do
-      let config = Config addr host port from fromName [(startingCycle, fee)] dbPath Nothing clientPath clientConfigFile startingCycle cycleLength snapshotInterval Nothing Nothing Nothing
+    Init addr host port from fromName fee dbPath clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay -> do
+      let config = Config addr host port from fromName [(startingCycle, fee)] dbPath Nothing clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay Nothing Nothing Nothing
       writeConfig configPath config
       exitSuccess
     Monitor -> withConfig $ \config -> do

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -17,7 +17,7 @@ data Options = Options {
 
 data Command =
   Version |
-  Init T.Text T.Text Int T.Text T.Text Rational T.Text T.Text T.Text Int Int Int |
+  Init T.Text T.Text Int T.Text T.Text Rational T.Text T.Text T.Text Int Int Int Int Int |
   Monitor |
   Payout Bool Bool Bool
 
@@ -39,7 +39,7 @@ versionOptions ∷ Parser Command
 versionOptions = pure Version
 
 initOptions ∷ Context -> Parser Command
-initOptions ctx = Init <$> addrOptions <*> hostOptions <*> portOptions <*> fromOptions <*> fromNameOptions <*> feeOptions <*> dbPathOptions ctx <*> clientPathOptions <*> clientConfigFileOptions <*> startingCycleOptions <*> cycleLengthOptions <*> snapshotIntervalOptions
+initOptions ctx = Init <$> addrOptions <*> hostOptions <*> portOptions <*> fromOptions <*> fromNameOptions <*> feeOptions <*> dbPathOptions ctx <*> clientPathOptions <*> clientConfigFileOptions <*> startingCycleOptions <*> cycleLengthOptions <*> snapshotIntervalOptions <*> preservedCyclesOptions <*> payoutDelayOptions
 
 addrOptions ∷ Parser T.Text
 addrOptions = T.pack <$> strOption (long "tz1" <> metavar "tz1" <> help "tz1 address of baker implicit account")
@@ -76,6 +76,12 @@ cycleLengthOptions = option auto (long "cycle-length" <> metavar "BLOCKS" <> hel
 
 snapshotIntervalOptions :: Parser Int
 snapshotIntervalOptions = option auto (long "snapshot-interval" <> metavar "BLOCKS" <> help "Interval between snapshots in blocks" <> showDefault <> value 256)
+
+preservedCyclesOptions :: Parser Int
+preservedCyclesOptions = option auto (long "preserved-cycles" <> metavar "BLOCKS" <> help "Preserved cycles constant, may be different for alphanet" <> showDefault <> value 5)
+
+payoutDelayOptions :: Parser Int
+payoutDelayOptions = option auto (long "payout-delay" <> metavar "BLOCKS" <> help "Delay in cycles to pay out delegators later or earlier than rewards unlocking" <> showDefault <> value 0)
 
 accountOptions :: Parser T.Text
 accountOptions = T.pack <$> strOption (long "account" <> metavar "ACCOUNT" <> help "Account name or KT1 address")


### PR DESCRIPTION
On Alphanet, the rights are calculated 3 cycles in the future.

Current version of the backerei software crashes against alphanet, because
it tries to query the future baking and endorsing rights up to 5 cycles
in the future. The error encountered is "unkown seed".

At least one other person had the problem:

https://github.com/cryptiumlabs/backerei/issues/24

The PR fixes it by making "preserved_cycles" a parameter.

Also add to README to explain that param should be changed for alphanet.

Add payout delay option.

Payout delay lets you pay your delgates later (or earlier) than when
the rewards are unfrozen.