### PR TITLE
`add an option to pay out estimated rewards instead of final rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ The default values for these constants work on the Tezos mainnet.
 * `--snapshot-interval` defaults to 512. For alphanet, set to 256
 * `--preserved-cycles`: defaults to 5. For alphanet, set to 3
 
+#### Estimated rewards vs final rewards
+
+The payout calculator assumes 100% liveness of your own baking and endorsing node, and pays
+accordingly. However, the effective rewards for a given baker also depends on the behaviour
+of other bakers in the network. For example, if bakers fail to endorse your block, or fail
+to include your endorsment in their block, then your rewards are lower.
+
+Estimated rewards assume perfect behaviour of the entire set of active delegates for
+a given block. Final rewards take into account the actual faulty behaviour of other nodes
+(not yours) and are accordingly a few percent lower.
+
 #### Delayed payouts
 
 By default, the payouts are paid after `PRESERVED_CYCLES`, which corresponds to when
@@ -93,6 +104,12 @@ the Tezos network unfreezes them. You may choose to pay them earlier or later:
 * `--payout-delay 2` will pay the rewards two cycles (six days) later
 * `--payout-delay -1` will pay the rewards one cycle (three days) before you actually
 get access to them
+
+You can not set a payout delay of less than negative `PRESERVED_CYCLES` because final
+rewards can not be computed before the cycle ends. However, you may set up a payout delay
+of up to `2*PRESERVED_CYCLES + 1` if you use the `--pay-estimated-rewards` option.
+
+This option will likely pay more than the final fee, so adjust your fee accordingly.
 
 #### Verifying payouts
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ the Tezos network unfreezes them. You may choose to pay them earlier or later:
 * `--payout-delay -1` will pay the rewards one cycle (three days) before you actually
 get access to them
 
-You can not set a payout delay of less than negative `PRESERVED_CYCLES` because final
+You cannot set a payout delay of less than negative `PRESERVED_CYCLES` because final
 rewards can not be computed before the cycle ends. However, you may set up a payout delay
 of up to `2*PRESERVED_CYCLES + 1` if you use the `--pay-estimated-rewards` option.
 

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -25,6 +25,7 @@ data Config = Config {
   configPreservedCycles      :: Int,
   configPayoutDelay          :: Int,
   configBabylonStartingCycle :: Int,
+  configPayEstimatedRewards  :: Bool,
   configTelegram             :: Maybe TelegramConfig,
   configRiemann              :: Maybe RiemannConfig,
   configPostPayoutScript     :: Maybe T.Text

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -52,8 +52,8 @@ run (Options configPath command) = do
     Version -> do
       putDoc versionDoc
       exitSuccess
-    Init addr host port from fromName fee dbPath clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay babylonStartingCycle -> do
-      let config = Config addr host port from fromName [(startingCycle, fee)] dbPath Nothing clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay babylonStartingCycle Nothing Nothing Nothing
+    Init addr host port from fromName fee dbPath clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay babylonStartingCycle payEstimatedRewards -> do
+      let config = Config addr host port from fromName [(startingCycle, fee)] dbPath Nothing clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay babylonStartingCycle payEstimatedRewards Nothing Nothing Nothing
       writeConfig configPath config
       exitSuccess
     Monitor -> withConfig $ \config -> do

--- a/app/Options.hs
+++ b/app/Options.hs
@@ -17,7 +17,7 @@ data Options = Options {
 
 data Command =
   Version |
-  Init T.Text T.Text Int T.Text T.Text Rational T.Text T.Text T.Text Int Int Int Int Int Int |
+  Init T.Text T.Text Int T.Text T.Text Rational T.Text T.Text T.Text Int Int Int Int Int Int Bool |
   Monitor |
   Payout Bool Bool Bool
 
@@ -39,7 +39,7 @@ versionOptions ∷ Parser Command
 versionOptions = pure Version
 
 initOptions ∷ Context -> Parser Command
-initOptions ctx = Init <$> addrOptions <*> hostOptions <*> portOptions <*> fromOptions <*> fromNameOptions <*> feeOptions <*> dbPathOptions ctx <*> clientPathOptions <*> clientConfigFileOptions <*> startingCycleOptions <*> cycleLengthOptions <*> snapshotIntervalOptions <*> preservedCyclesOptions <*> payoutDelayOptions <*> babylonStartingCycleOptions
+initOptions ctx = Init <$> addrOptions <*> hostOptions <*> portOptions <*> fromOptions <*> fromNameOptions <*> feeOptions <*> dbPathOptions ctx <*> clientPathOptions <*> clientConfigFileOptions <*> startingCycleOptions <*> cycleLengthOptions <*> snapshotIntervalOptions <*> preservedCyclesOptions <*> payoutDelayOptions <*> babylonStartingCycleOptions <*> payEstimatedRewards
 
 addrOptions ∷ Parser T.Text
 addrOptions = T.pack <$> strOption (long "tz1" <> metavar "tz1" <> help "tz1 address of baker implicit account")
@@ -85,6 +85,9 @@ preservedCyclesOptions = option auto (long "preserved-cycles" <> metavar "BLOCKS
 
 payoutDelayOptions :: Parser Int
 payoutDelayOptions = option auto (long "payout-delay" <> metavar "BLOCKS" <> help "Delay in cycles to pay out delegators later or earlier than rewards unlocking" <> showDefault <> value 0)
+
+payEstimatedRewards :: Parser Bool
+payEstimatedRewards = switch (long "pay-estimated-rewards" <> help "Pay out reward estimates instead of realized rewards")
 
 accountOptions :: Parser T.Text
 accountOptions = T.pack <$> strOption (long "account" <> metavar "ACCOUNT" <> help "Account name or KT1 address")

--- a/app/Payout.hs
+++ b/app/Payout.hs
@@ -23,7 +23,7 @@ import           Config
 import           DB
 
 payout :: Config -> Bool -> Maybe T.Text -> Bool -> (T.Text -> IO ()) -> IO ()
-payout (Config baker host port from fromName varyingFee databasePath accountDatabasePath clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay babylonStartingCycle _ _ maybePostPayoutScript) noDryRun fromPassword continuous notify = do
+payout (Config baker host port from fromName varyingFee databasePath accountDatabasePath clientPath clientConfigFile startingCycle cycleLength snapshotInterval preservedCycles payoutDelay babylonStartingCycle payEstimatedRewards _ _ maybePostPayoutScript) noDryRun fromPassword continuous notify = do
   let conf = RPC.Config host port
 
       isBabylon cycle = cycle >= babylonStartingCycle
@@ -122,15 +122,17 @@ payout (Config baker host port from fromName varyingFee databasePath accountData
         return (res, (updated, return ()))
 
       maybePayoutDelegatorsForCycle cycle delegators db = do
-        let needToPay = P.filter (\(_, delegator) -> case (delegatorPayoutOperationHash delegator, delegatorFinalRewards delegator) of (Nothing, Just amount) | amount > 0 -> True; _ -> False) $ M.toList delegators
+        let needToPay = if payEstimatedRewards then P.filter (\(_, delegator) -> case delegatorPayoutOperationHash delegator of Nothing -> True; _ -> False) $ M.toList delegators else P.filter (\(_, delegator) -> case (delegatorPayoutOperationHash delegator, delegatorFinalRewards delegator) of (Nothing, Just amount) | amount > 0 -> True; _ -> False) $ M.toList delegators
             toPay     = P.take 100 needToPay
         if null toPay then return (db, (False, return ())) else do
           forM_ toPay $ \(address, delegator) -> do
-            let Just amount = delegatorFinalRewards delegator
-            T.putStrLn $ T.concat ["For cycle ", T.pack $ P.show cycle, " delegator ", address, " should be paid ", T.pack $ P.show amount, " XTZ"]
+            if payEstimatedRewards then
+              T.putStrLn $ T.concat ["For cycle ", T.pack $ P.show cycle, " delegator ", address, " should be paid estimated rewards of ", T.pack $ P.show $ delegatorEstimatedRewards delegator, " XTZ"]
+            else
+              T.putStrLn $ T.concat ["For cycle ", T.pack $ P.show cycle, " delegator ", address, " should be paid final rewards of ", T.pack $ P.show $ fromJust (delegatorFinalRewards delegator), " XTZ"]
           (updatedDelegators, action) <-
             if noDryRun then do
-              let dests = fmap (\(address, delegator) -> (address, let Just amount = delegatorFinalRewards delegator in amount)) toPay
+              let dests = if payEstimatedRewards then fmap (\(address, delegator) -> (address, delegatorEstimatedRewards delegator)) toPay else fmap (\(address, delegator) -> (address, let Just amount = delegatorFinalRewards delegator in amount)) toPay
               hash <- RPC.sendTezzies conf from fromName dests (sign clientPath clientConfigFile fromPassword)
               threadDelay 600000000
               if length toPay == length needToPay then do
@@ -146,7 +148,7 @@ payout (Config baker host port from fromName varyingFee databasePath accountData
           Nothing -> error "should not happen: missed lookup"
           Just cyclePayout -> do
             let delegators = cycleDelegators cyclePayout
-                total = P.sum $ fmap (fromJust . delegatorFinalRewards) $ P.filter (isJust . delegatorFinalRewards) $ P.filter (isNothing . delegatorPayoutOperationHash) $ M.elems delegators
+            let total = if payEstimatedRewards then P.sum $ fmap delegatorEstimatedRewards $ P.filter (isNothing . delegatorPayoutOperationHash) $ M.elems delegators else P.sum $ fmap (fromJust . delegatorFinalRewards) $ P.filter (isJust . delegatorFinalRewards) $ P.filter (isNothing . delegatorPayoutOperationHash) $ M.elems delegators
             if total == 0 then return (db, (False, return ())) else do
               balance <- RPC.balanceAt conf RPC.head from
               T.putStrLn $ T.concat ["Total payouts: ", T.pack $ P.show total, ", payout account balance: ", T.pack $ P.show balance]

--- a/app/Payout.hs
+++ b/app/Payout.hs
@@ -122,7 +122,7 @@ payout (Config baker host port from fromName varyingFee databasePath accountData
         return (res, (updated, return ()))
 
       maybePayoutDelegatorsForCycle cycle delegators db = do
-        let needToPay = if payEstimatedRewards then P.filter (\(_, delegator) -> case delegatorPayoutOperationHash delegator of Nothing -> True; _ -> False) $ M.toList delegators else P.filter (\(_, delegator) -> case (delegatorPayoutOperationHash delegator, delegatorFinalRewards delegator) of (Nothing, Just amount) | amount > 0 -> True; _ -> False) $ M.toList delegators
+        let needToPay = if payEstimatedRewards then P.filter (\(_, delegator) -> case (delegatorPayoutOperationHash delegator, delegatorEstimatedRewards delegator) of (Nothing, amount) | amount > 0 -> True; _ -> False) $ M.toList delegators else P.filter (\(_, delegator) -> case (delegatorPayoutOperationHash delegator, delegatorFinalRewards delegator) of (Nothing, Just amount) | amount > 0 -> True; _ -> False) $ M.toList delegators
             toPay     = P.take 100 needToPay
         if null toPay then return (db, (False, return ())) else do
           forM_ toPay $ \(address, delegator) -> do


### PR DESCRIPTION
(defaults to no)

You can pay estimated rewards by passing argument --pay-estimated-rewards
and with this option set you are able to pay out up to 11 cycles
earlier than the default (on mainnet).