### PR TITLE
Add Dockerfile and gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+image: docker:stable
+services:
+  - docker:dind
+
+variables:
+  DOCKER_HOST: tcp://docker:2375
+  DOCKER_DRIVER: overlay2
+  IMAGE_TAG: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+  IMAGE_LATEST_TAG: $CI_REGISTRY_IMAGE:latest
+
+before_script:
+  - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+
+build:
+  stage: build
+  script:
+    - docker build -t $IMAGE_TAG .
+    - docker push $IMAGE_TAG
+    - docker build -t $IMAGE_LATEST_TAG .
+    - docker push $IMAGE_LATEST_TAG
+  only:
+    refs:
+      - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM alpine AS base
+
+RUN apk update && \
+    apk add bash perl alpine-sdk wget curl libc-dev xz
+
+
+################################################################################
+# Intermediate layer that assembles 'stack' tooling
+FROM base AS stack
+
+ENV STACK_VERSION=1.9.3
+ENV STACK_SHA256="c9bf6d371b51de74f4bfd5b50965966ac57f75b0544aebb59ade22195d0b7543  stack-${STACK_VERSION}-linux-x86_64-static.tar.gz"
+
+RUN echo "Downloading stack" &&\
+    cd /tmp &&\
+    wget -P /tmp/ "https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/stack-${STACK_VERSION}-linux-x86_64-static.tar.gz" &&\
+    if ! echo -n "${STACK_SHA256}" | sha256sum -c -; then \
+        echo "stack-${STACK_VERSION} checksum failed" >&2 &&\
+        exit 1 ;\
+    fi ;\
+    tar -xvzf /tmp/stack-${STACK_VERSION}-linux-x86_64-static.tar.gz &&\
+    cp -L /tmp/stack-${STACK_VERSION}-linux-x86_64-static/stack /usr/bin/stack &&\
+    rm /tmp/stack-${STACK_VERSION}-linux-x86_64-static.tar.gz &&\
+    rm -rf /tmp/stack-${STACK_VERSION}-linux-x86_64-static
+################################################################################
+
+
+FROM stack as stack_intermediate
+
+ENV GHC_VERSION=8.4.4
+ENV GHC_INSTALL_PATH=/opt/ghc
+
+RUN wget https://github.com/redneb/ghc-alt-libc/releases/download/ghc-${GHC_VERSION}-musl/ghc-${GHC_VERSION}-x86_64-unknown-linux-musl.tar.xz && \
+    tar xf ghc-${GHC_VERSION}-x86_64-unknown-linux-musl.tar.xz
+
+RUN apk update && \
+    apk add bash perl alpine-sdk wget make curl git libc-dev xz coreutils zlib-dev shadow gmp-dev
+
+
+WORKDIR ghc-${GHC_VERSION}
+
+RUN ./configure --prefix=${GHC_INSTALL_PATH} && \
+        make install
+
+ENV PATH=${GHC_INSTALL_PATH}/bin:$PATH
+
+COPY --from=stack /usr/bin/stack /usr/bin/stack
+RUN stack config set system-ghc --global true
+RUN mkdir /build
+COPY . /build
+RUN cd /build && make build && make install
+
+FROM tezos/tezos:mainnet
+COPY --from=stack_intermediate /root/.local/bin/backerei /home/tezos
+WORKDIR /home/tezos
+ENTRYPOINT ["./backerei"]

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - .
 extra-deps:
 - posix-pty-0.2.1.1
-- git: git@github.com:shmish111/hriemann.git
+- git: https://github.com/shmish111/hriemann.git
   commit: 9526dbc0b07ea37f37f4753177390df10385fe83
 - kazura-queue-0.1.0.4@sha256:24c26a38b98c49c6f6448410e8d7499c88be423bba75a204a7f9a8155c5cda41
 - unagi-chan-0.4.1.0@sha256:97e08dd9a73462ca284bfd2f904cd471c94e1207c2dd79a59efcc8fe2c93de41


### PR DESCRIPTION
The dockerfile build backerei and add it to the tezos mainnet container.
The resulting container is an autonomous payout entity able to connect
to a tezos node with rpc to send payouts.

To trigger ci/cd and validate correct build on every commit, set up
a gitlab mirror of the github repo. This is currently the most
straightforward way to get a free pipeline for an open source project.

Note: modified stack.yaml to clone from https instead of git, because
otherwise a keypair is needed locally, which is not the case during
CI builds.