### PR TITLE
Update tezos blockchain explorer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ realized fees). This is roughly equivalent to insuring liveness.
 
 #### Initialization
 
-Initialize Bäckerei with the tz1 address of your baker, for example that of 
-[Cryptium Labs](https://tzscan.io/tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8),
+Initialize Bäckerei with the tz1 address of your baker, for example that of
+[Cryptium Labs](https://tzstats.com/tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8),
 the address you want to send payouts from, the alias associated with that address,
 the path to your database file, and the first cycle in which you baked or endorsed blocks:
 


### PR DESCRIPTION
tzscan.io is no longer serving tezos blockchain explorers.
tzscan.com still is.

Compare tzscan.io
![image](https://user-images.githubusercontent.com/6826729/74212620-e0704880-4c49-11ea-8f5e-df68071e2f79.png)

To [tzscan.com](https://tzstats.com/tz1eEnQhbwf6trb8Q8mPb2RaPkNk2rN7BKi8)

![image](https://user-images.githubusercontent.com/6826729/74212631-f847cc80-4c49-11ea-8d8b-7e2b8e0172b6.png)
