### PR TITLE
Fix issue with payout signatures in containerized case

### DIFF
--- a/app/Payout.hs
+++ b/app/Payout.hs
@@ -355,10 +355,10 @@ sign clientPath clientConfigFile fromPassword account what = do
           exitFailure
         else do
           let asText = T.pack $ B.unpack stdout
-          return asText
+          return $ T.drop 13 $ T.take (T.length asText - 2) asText
       Nothing -> do
         T.putStrLn $ T.concat ["Running '", T.intercalate " " (clientPath : args), "' in a subprocess"]
-        result <- try' $ P.createProcess (P.proc (P.show clientPath) (P.map P.show args)){ P.std_out = P.CreatePipe }
+        result <- try' $ P.createProcess (P.proc (T.unpack clientPath) (fmap T.unpack args)){ P.std_out = P.CreatePipe }
         case result of
           Left ex -> do
             T.putStrLn $ T.concat [ "Subprocess returned an exception: ", T.pack $ P.show ex ]
@@ -369,7 +369,7 @@ sign clientPath clientConfigFile fromPassword account what = do
           Right (_, Just hout, _, _) -> do
             T.putStrLn "Success"
             asText <- T.hGetContents hout
-            return asText
+            return $ T.drop 11 $ T.take (T.length asText - 1) asText
   T.putStrLn "> output of signature"
   T.putStrLn asText
-  return $ T.drop 13 $ T.take (T.length asText - 2) asText
+  return asText


### PR DESCRIPTION
We have previously introduced a new argument to payouts
--no-password. When that argument is passed, tezos-client
is spawned in a subprocess instead of a tty.

When running as a subprocess, the stdin/stdout handling
is different. This change fixes the subprocess case, and it does
not change the tty spawning case used by Cryptium.

This change was erroneously left out in a previous PR, so the
--no-password argument is broken unless this code gets merged.