### PR TITLE
Containerized build & ci : pin alpine to a known good version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine AS base
+FROM alpine@sha256:c19173c5ada610a5989151111163d28a67368362762534d8a8121ce95cf2bd5a AS base
 
 RUN apk update && \
     apk add bash perl alpine-sdk wget curl libc-dev xz


### PR DESCRIPTION
We are building backerei in a container. Since backerei runs tezos-client
in a subprocess to sign operations, tezos-client needs to be present
in the same container.

Tezos-client and backerei are linked binaries, they depend on system
libraries to run. The tezos container is built on top of alpine. So
backerei also needs to be built on top of alpine, so both utilities
run against the musl c libraries that alpine uses.

Building haskell binaries in an alpine environment is convoluted.
There is an unofficial ghc-alt-libc package that is maintained (*),
that gets installed in the container, so backerei can build.

(*) https://github.com/redneb/ghc-alt-libc

This works on a version of alpine from a few months ago.

Recently I rebuilt the container to import a tezos-client that
works with Carthage, but I found that it was no longer working. The
error was:

Pinning the alpine version from a few months ago fixed it, but that
is hardly a satisfactory solution. Instead, it appears that a later
version of GHC does not have such issue, but that would require
upgrading the version of stack as well, which probably means that
the backerei codebase itself needs to change.

It is beyond my haskell skills to do so, if the maintainers could do
it, that would be greatly appeciated.