### PR TITLE
fix #62 where the baker is erroneously counted as a delegate

### DIFF
--- a/src/Backerei/Delegation.hs
+++ b/src/Backerei/Delegation.hs
@@ -2,7 +2,7 @@ module Backerei.Delegation where
 
 import           Control.Applicative
 import           Control.Monad
-import           Data.List           (zip)
+import           Data.List           (zip, delete)
 import qualified Data.Text           as T
 import qualified Data.Text.IO        as T
 import           Foundation
@@ -14,7 +14,7 @@ import           Backerei.Types
 getContributingBalancesFor :: RPC.Config -> Int -> Int -> Int -> T.Text -> IO ([(T.Text, Tezzies)], Tezzies)
 getContributingBalancesFor config cycleLength snapshotInterval cycle delegate = do
   snapshotBlockHash <- snapshotHash config cycle cycleLength snapshotInterval
-  delegators <- RPC.delegatedContracts config snapshotBlockHash delegate
+  delegators <- delete delegate <$> RPC.delegatedContracts config snapshotBlockHash delegate
   balances <- mapM (RPC.balanceAt config snapshotBlockHash) delegators
   fullBalance <- RPC.delegateBalanceAt config snapshotBlockHash delegate
   frozenByCycle <- RPC.frozenBalanceByCycle config snapshotBlockHash delegate


### PR DESCRIPTION
The RPC may have changed, so it does not happen with all bakers, but
in many cases, the baker pubkey hash is part of the list of delegators
which cause a safety check to fail. We are explicitely removing it if
it is present.