### PR TITLE
stopgap solution for smart contract payouts

### DIFF
--- a/src/Backerei/RPC.hs
+++ b/src/Backerei/RPC.hs
@@ -100,7 +100,7 @@ sendTezzies :: Config -> T.Text -> T.Text -> [(T.Text, Tezzies)] -> (T.Text -> T
 sendTezzies config from fromName dests sign = do
   currentCounter <- counter config head from
   let txns = fmap (\((dest, amount), counter) -> A.toJSON $ M.fromList [("kind" :: T.Text, A.String "transaction"), ("amount", A.toJSON amount), ("source", A.toJSON from),
-                ("destination", A.String dest), ("storage_limit", A.String "0"), ("gas_limit", A.String "16000"), ("fee", A.toJSON $ Tezzies $ 0.002120), ("counter", A.toJSON $ P.show counter)]) (P.zip dests [currentCounter + 1 ..])
+                ("destination", A.String dest), ("storage_limit", A.String (if T.take 2 dest == "KT" then "4" else "0")), ("gas_limit", A.String (if T.take 2 dest == "KT" then "1000000" else "16000")), ("fee", A.toJSON $ Tezzies $ (if T.take 2 dest == "KT" then 0.1 else 0.002120)), ("counter", A.toJSON $ P.show counter)]) (P.zip dests [currentCounter + 1 ..])
   (BlockHeader hashHead _ _ _) <- header config head
   (BlockMetadata protocolHead _ _) <- metadata config hashHead
   let fakeSignature = "edsigtXomBKi5CTRf5cjATJWSyaRvhfYNHqSUGrn4SdbYRcGwQrUGjzEfQDTuqHhuA8b2d8NarZjz8TRf65WkpQmo423BtomS8Q" :: T.Text


### PR DESCRIPTION
New Defi smart contracts such as Kolibri have expensive payout
operations. Backerei fee/storage/gas parameters for payout operations
are hardcoded in values that are too low for payouts to work.

This results in "simulation failure" whenever someone delegates
a Kolibri smart contract to your baker.

This PR fixes it in a very crude way, by setting high limits and fees
to every smart contract, and the usual low fee to tz addresses.

It will probably fail when there are too many Kolibri delegators
attached to your baker. Backerei has a mechanism to split payouts
across several blocks, but it does not take this new change into
account.

This should be replaced by a mechanism to estimate the fee for
every payout and charge it back to the delegator.

I don't think anyone will take that on, so the actual recommendation
is to switch to maintained payout software such as TRD.

May I have merge permissions for this repository as well?